### PR TITLE
fix test/ops/self_attention.py

### DIFF
--- a/test/ops/self_attention.py
+++ b/test/ops/self_attention.py
@@ -15,7 +15,7 @@ def torch_self_attention(attn_val, query, key, value, scale):
     L, S = query.size(-2), key.size(-2)
     attn_bias = torch.zeros(L, S, dtype=query.dtype, device=query.device)
 
-    temp_mask = torch.ones(S, S, dtype=torch.bool).tril(diagonal=0)[-L:, ]
+    temp_mask = torch.ones(L, S, dtype=torch.bool).tril(diagonal=S-L)
     attn_bias.masked_fill_(temp_mask.logical_not(), float("-inf"))
     attn_bias.to(query.dtype)
 

--- a/test/ops/self_attention.py
+++ b/test/ops/self_attention.py
@@ -15,7 +15,7 @@ def torch_self_attention(attn_val, query, key, value, scale):
     L, S = query.size(-2), key.size(-2)
     attn_bias = torch.zeros(L, S, dtype=query.dtype, device=query.device)
 
-    temp_mask = torch.ones(L, S, dtype=torch.bool).tril(diagonal=0)
+    temp_mask = torch.ones(S, S, dtype=torch.bool).tril(diagonal=0)[-L:, ]
     attn_bias.masked_fill_(temp_mask.logical_not(), float("-inf"))
     attn_bias.to(query.dtype)
 


### PR DESCRIPTION
我在实现 kvcache 后，发现 Prefill 阶段得到的 token 正确，Decode 阶段得到的 token 不对，通过查看张量，发现 self-attention 部分有问题，最终定位到 softmax 有问题，发现我实现的 self-attention 算子的 softmax 的部分不对（当 qlen != kvlen 时，也就是用 kvcache 时），但是通过了 test/ops/self-attention.py 的测试，在我的视线中增加 past_len = total_len - seqlen 之后，可以正确推理，但是通不过 self-attention 的测试了，以此推论 test/ops/self-attention.py 也有问题。

分析：
```
# 之前的实现
temp_mask = torch.ones(L, S, dtype=torch.bool).tril(diagonal=0)
# 修改后的实现    
temp_mask = torch.ones(S, S, dtype=torch.bool).tril(diagonal=0)[-L:, ]
```

之前测试中的 mask 内容：

<img width="816" height="244" alt="image" src="https://github.com/user-attachments/assets/75100b74-629c-4876-9489-b572afd4b197" />

mask 应该具有的正确内容：
<img width="835" height="249" alt="image" src="https://github.com/user-attachments/assets/834ad9dd-4fd6-492a-a2d7-84c539b1e7a2" />

修改这一部分的逻辑之后，self-attention 和 infer 的 CI 测试都可以通过了。

下图是通过 CI 的截图：
<img width="1425" height="615" alt="image" src="https://github.com/user-attachments/assets/5731be59-6205-4130-b438-e9d2b5e01efb" />
