### PR TITLE
fix: fix missing assert in embedding.py

### DIFF
--- a/test/ops/embedding.py
+++ b/test/ops/embedding.py
@@ -25,7 +25,7 @@ def test_op_embedding(
     torch_embedding(out, idx, embd)
     llaisys.Ops.embedding(out_, idx_, embd_)
 
-    check_equal(out_, out, strict=True)
+    assert check_equal(out_, out, strict=True)
 
     if profile:
         benchmark(


### PR DESCRIPTION
我在实现embedinng的时候，错误地实现为1D的index数组永远只有一个元素，即只需要取一行。

```c++
    size_t offset = idx * weight->strides()[0] * llaisys::utils::dsize(weight->dtype()); // units: byte
    size_t embedding_dim = weight->shape()[1]; 

    if (weight->deviceType() == LLAISYS_DEVICE_CPU) {
        return cpu::embedding(out->data(), weight->data() + offset, weight->dtype(), 
                              embedding_dim); 
    }
```

运行embeding对应的测试文件
```python
python test/ops/embedding.py 
```
部分结果如下图：
<img width="403" height="255" alt="image" src="https://github.com/user-attachments/assets/3d44ac91-c702-4b3c-9cfe-dd8b80e46b2e" />

测试程序按预期输出了不同的的部分，但是却意外地仍然输出 “Test passed!”


定位错误在出在函数 test_op_embedding中
```python
    check_equal(out_, out, strict=True)
```
没有对check_equal的返回值做任何处理，于是程序在测试出错的时候仍然非预期执行最后的输出
```python
   print("\033[92mTest passed!\033[0m\n")
```

按照其他测试文件的风格，修改如下
```python
    assert check_equal(out_, out, strict=True)
```
程序按预期断言错误
<img width="575" height="97" alt="image" src="https://github.com/user-attachments/assets/cb624e95-7030-481f-9433-190cf53a72de" />






