### PR TITLE
fix: fix device of temp_mask when using cuda

### DIFF
--- a/test/ops/self_attention.py
+++ b/test/ops/self_attention.py
@@ -15,7 +15,7 @@ def torch_self_attention(attn_val, query, key, value, scale):
     L, S = query.size(-2), key.size(-2)
     attn_bias = torch.zeros(L, S, dtype=query.dtype, device=query.device)
 
-    temp_mask = torch.ones(L, S, dtype=torch.bool).tril(diagonal=S-L)
+    temp_mask = torch.ones(L, S, dtype=torch.bool, device=query.device).tril(diagonal=S-L)
     attn_bias.masked_fill_(temp_mask.logical_not(), float("-inf"))
     attn_bias.to(query.dtype)
 


### PR DESCRIPTION
```C++
temp_mask = torch.ones(L, S, dtype=torch.bool).tril(diagonal=S-L)
```

temp_mask 默认在CPU创建了张量，当在CPU上测试算子的时候没有任何问题，而当在CUDA上测试的时候就会报错，报错信息如下：
```
RuntimeError: expected self and mask to be on the same device, but got mask on cpu and self on cuda:0
```
<img width="599" height="145" alt="image" src="https://github.com/user-attachments/assets/d5933c94-e712-403b-87d1-612af167f1d5" />





解决方法：
对temp_mask也加上device=query.device，使得它和手动创建的query在同一设备上
```C++
temp_mask = torch.ones(L, S, dtype=torch.bool, device=query.device).tril(diagonal=S-L)
```

效果：
<img width="553" height="131" alt="image" src="https://github.com/user-attachments/assets/8da36887-1a70-4648-bd71-d74fd432bd7e" />

