### PR TITLE
fix build failure on macOS by updating xmake.lua

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -118,5 +118,8 @@ target("llaisys")
         if is_plat("linux") then
             os.cp("lib/*.so", "python/llaisys/libllaisys/")
         end
+        if is_plat("macosx") then
+            os.cp("lib/*.dylib", "python/llaisys/libllaisys/")
+        end
     end)
 target_end()


### PR DESCRIPTION
在 macOS系统上，xmake.lua步骤此前漏掉了对 .dylib 文件的处理，导致 Python 端运行测试时提示找不到共享库。